### PR TITLE
Fix: Restrict access to organizer dashboard summary route

### DIFF
--- a/backend/src/controllers/dashboardController.js
+++ b/backend/src/controllers/dashboardController.js
@@ -1,9 +1,22 @@
 import db from '../utils/db.js';
+import User from '../models/User.js';
+import { sendResponse } from '../utils/sendResponse.js';
 
 export const getOrganizerSummary = async (req, res) => {
   const { id } = req.params;
 
+  // Enforce organizer access to only their own data
+  if (req.user.id != id || req.user.role !== 'Organizer') {
+    return sendResponse(res, 403, 'Access denied');
+  }
+
   try {
+    // Check if the user exists and is an organizer
+    const organizer = await User.findById(id);
+    if (!organizer || organizer.role !== 'Organizer') {
+      return sendResponse(res, 404, 'Organizer not found');
+    }
+
     const [[{ total_events }]] = await db.execute(
       `SELECT COUNT(*) AS total_events FROM events WHERE organizer_id = ?`,
       [id]
@@ -25,16 +38,13 @@ export const getOrganizerSummary = async (req, res) => {
       [id]
     );
 
-    res.status(200).json({
-      success: true,
-      data: {
-        total_events,
-        total_rsvps,
-        avg_rating: avg_rating !== null ? Number(parseFloat(avg_rating).toFixed(2)) : 0
-      }
+    return sendResponse(res, 200, 'Dashboard summary fetched', {
+      total_events,
+      total_rsvps,
+      avg_rating: avg_rating !== null ? Number(parseFloat(avg_rating).toFixed(2)) : 0,
     });
   } catch (err) {
     console.error('Organizer summary error:', err.message);
-    res.status(500).json({ success: false, message: 'Failed to load summary' });
+    return sendResponse(res, 500, 'Failed to load summary');
   }
 };


### PR DESCRIPTION
This PR adds proper validation to the GET /dashboard/organizer/:id/summary route:

- Organizer can only access their own summary
- Prevents access using mismatched or invalid organizer ID
- Blocks access from other roles (e.g., Student, Admin)
- Returns 403 Access Denied or 404 Organizer not found accordingly